### PR TITLE
Fixed example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Usage
 The `node-applescript` module provides `execString` and `execFile` functions
 to easily execute AppleScript commands and buffer the output into a calback.
 
-    var applescript = require("node-applescript");
+    var applescript = require("applescript");
     
     // Very basic AppleScript command. Returns the song name of each
     // currently selected track in iTunes as an 'Array' of 'String's.


### PR DESCRIPTION
doing require('node-applescript') results in a failure: Error: Cannot find module 'node-applescript'
