### PR TITLE
allow for no callback

### DIFF
--- a/lib/applescript.js
+++ b/lib/applescript.js
@@ -50,7 +50,9 @@ function runApplescript(strOrPath, args, callback) {
       err.appleScript = strOrPath;
       err.exitCode = code;
     }
-    callback(err, result, interpreter.stderr.body);
+    if (callback) {
+      callback(err, result, interpreter.stderr.body);
+    }
   });
   
   if (isString) {


### PR DESCRIPTION
The current implementation fails if no callback is provided. This PR just does a check to make sure it's defined before attempting to call the function. Makes usage simpler for use cases that don't require a callback.
