### PR TITLE
fix arg order

### DIFF
--- a/lib/applescript.js
+++ b/lib/applescript.js
@@ -28,15 +28,15 @@ function runApplescript(strOrPath, args, callback) {
     args = [];
     isString = true;
   }
-  
-  // args get added in reverse order with 'unshift'
+
+  // args get added to the end of the args array
+  args.push("-ss"); // To output machine-readable text.
   if (!isString) {
     // The name of the file is the final arg if 'execFile' was called.
-    args.unshift(strOrPath);
+    args.push(strOrPath);
   }
-  args.unshift("-ss"); // To output machine-readable text.
   var interpreter = spawn(exports.osascript, args);
-  
+
   bufferBody(interpreter.stdout);
   bufferBody(interpreter.stderr);
 
@@ -54,7 +54,7 @@ function runApplescript(strOrPath, args, callback) {
       callback(err, result, interpreter.stderr.body);
     }
   });
-  
+
   if (isString) {
     // Write the given applescript String to stdin if 'execString' was called.
     interpreter.stdin.write(strOrPath);


### PR DESCRIPTION
I was trying to use the language flag, `-lJavaScript`, to take advantage of the new JXA support in Yosemite. Because the file path was being unshifted on to the front of the args, it wasn't working, so I switched to push.