### PR TITLE
Wait for input streams to close

### DIFF
--- a/lib/applescript.js
+++ b/lib/applescript.js
@@ -40,7 +40,7 @@ function runApplescript(strOrPath, args, callback) {
   bufferBody(interpreter.stdout);
   bufferBody(interpreter.stderr);
 
-  interpreter.on('exit', function(code) {
+  interpreter.on('close', function(code) {
     var result = parse(interpreter.stdout.body);
     var err;
     if (code) {


### PR DESCRIPTION
As seen here: https://nodejs.org/api/child_process.html#child_process_event_exit, when listening on 'exit', child process stdio streams might still be open. I am missing output because of this (randomly). So wait for the close event should fix this 😊
