### PR TITLE
Add backwards compatible support for Promise based api

### DIFF
--- a/lib/applescript.js
+++ b/lib/applescript.js
@@ -20,46 +20,52 @@ exports.execString = function execString(str, callback) {
 }
 
 
-
 function runApplescript(strOrPath, args, callback) {
-  var isString = false;
-  if (!Array.isArray(args)) {
-    callback = args;
-    args = [];
-    isString = true;
-  }
-
-  // args get added in reverse order with 'unshift'
-  if (!isString) {
-    // The name of the file is the final arg if 'execFile' was called.
-    args.unshift(strOrPath);
-  }
-  args.unshift("-ss"); // To output machine-readable text.
-  var interpreter = spawn(exports.osascript, args);
-
-  bufferBody(interpreter.stdout);
-  bufferBody(interpreter.stderr);
-
-  interpreter.on('close', function(code) {
-    var result = parse(interpreter.stdout.body);
-    var err;
-    if (code) {
-      // If the exit code was something other than 0, we're gonna
-      // return an Error object.
-      err = new Error(interpreter.stderr.body);
-      err.appleScript = strOrPath;
-      err.exitCode = code;
+  return new Promise((resolve, reject) => {
+    var isString = false;
+    if (!Array.isArray(args)) {
+      callback = args;
+      args = [];
+      isString = true;
     }
-    if (callback) {
-      callback(err, result, interpreter.stderr.body);
+
+    // args get added in reverse order with 'unshift'
+    if (!isString) {
+      // The name of the file is the final arg if 'execFile' was called.
+      args.unshift(strOrPath);
+    }
+    args.unshift("-ss"); // To output machine-readable text.
+    var interpreter = spawn(exports.osascript, args);
+
+    bufferBody(interpreter.stdout);
+    bufferBody(interpreter.stderr);
+
+    interpreter.on("close", function(code) {
+      var result = parse(interpreter.stdout.body);
+      var err;
+      if (code) {
+        // If the exit code was something other than 0, we're gonna
+        // return an Error object.
+        err = new Error(interpreter.stderr.body);
+        err.appleScript = strOrPath;
+        err.exitCode = code;
+      }
+      if (callback) {
+        callback(err, result, interpreter.stderr.body);
+      }
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result, interpreter.stderr.body);
+      }
+    });
+
+    if (isString) {
+      // Write the given applescript String to stdin if 'execString' was called.
+      interpreter.stdin.write(strOrPath);
+      interpreter.stdin.end();
     }
   });
-
-  if (isString) {
-    // Write the given applescript String to stdin if 'execString' was called.
-    interpreter.stdin.write(strOrPath);
-    interpreter.stdin.end();
-  }
 }
 
 function bufferBody(stream) {


### PR DESCRIPTION
Tested with this code:

```
applescript
  .execString(script)
  .then(rtn => {
    if (Array.isArray(rtn) && rtn.length > 0) {
      console.log('Currently selected tracks in "iTunes":');
      rtn.forEach(function(songName) {
        console.log("\t" + songName);
      });
    } else {
      console.log('No tracks are selected in "iTunes"...');
    }
  })
  .catch(err => {
    console.log(err);
  });
```

It will enable to use node-applescript with modern async/await code.