### PR TITLE
Add a timeout parameter for the child spawn process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ applescript.execString(script, (err, rtn) => {
 (`*.applescript`) file as the first argument instead of the command itself, and you
 may pass an optional Array of String arguments to send to the applescript file.
 
+Each function takes an optional last parameter timeout (in milliseconds) to kill the
+applescript process if it stops responding.
+
 Licence
 -------
 

--- a/lib/applescript.js
+++ b/lib/applescript.js
@@ -6,24 +6,25 @@ var parse = exports.Parsers.parse;
 exports.osascript = "osascript";
 
 // Execute a *.applescript file.
-exports.execFile = function execFile(file, args, callback) {
+exports.execFile = function execFile(file, args, callback, timeout) {
   if (!Array.isArray(args)) {
     callback = args;
     args = [];
   }
-  return runApplescript(file, args, callback);
+  return runApplescript(file, args, callback, timeout);
 }
 
 // Execute a String as AppleScript.
-exports.execString = function execString(str, callback) {
-  return runApplescript(str, callback);
+exports.execString = function execString(str, callback, timeout) {
+  return runApplescript(str, callback, timeout);
 }
 
 
 
-function runApplescript(strOrPath, args, callback) {
+function runApplescript(strOrPath, args, callback, timeout) {
   var isString = false;
   if (!Array.isArray(args)) {
+    timeout = callback;
     callback = args;
     args = [];
     isString = true;
@@ -59,6 +60,12 @@ function runApplescript(strOrPath, args, callback) {
     // Write the given applescript String to stdin if 'execString' was called.
     interpreter.stdin.write(strOrPath);
     interpreter.stdin.end();
+  }
+
+  if (timeout) {
+    setTimeout(function() {
+      if (interpreter.exitCode == null) interpreter.kill()
+    }, timeout);
   }
 }
 


### PR DESCRIPTION
We've found that we want some way to keep the osascript process from taking a long time, so I added a timeout parameter to kill the subprocess after a given time.